### PR TITLE
Update ev3dev-lang to ev3dev/ev3dev-lang#169

### DIFF
--- a/ev3dev.h
+++ b/ev3dev.h
@@ -37,6 +37,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <tuple>
 #include <vector>
 #include <algorithm>
 #include <functional>
@@ -481,6 +482,12 @@ public:
   int rate(bool do_set_mode = true) {
     if (do_set_mode) set_mode(mode_gyro_rate);
     return value(0);
+  }
+
+  // Angle (degrees) and Rotational Speed (degrees/second).
+  std::tuple<int, int> rate_and_angle(bool do_set_mode = true) {
+    if (do_set_mode) set_mode(mode_gyro_g_a);
+    return std::make_tuple( value(0), value(1) );
   }
 
 };

--- a/templates/special-sensor-declaration.liquid
+++ b/templates/special-sensor-declaration.liquid
@@ -20,21 +20,42 @@ public:
 endfor %}
 {% for mapping in currentClass.sensorValueMappings %}{%
   assign name = mapping.name | downcase | underscore_spaces %}{%
-  assign mode = mapping.requiredMode | downcase | underscore_non_wc %}{%
-  assign value_index = mapping.sourceValue %}{%
-  assign type = mapping.type %}{%
-  assign reader = 'value' %}{%
-  if type == 'float' %}{%
-    assign reader = 'float_value' %}{%
-  elsif type == 'boolean' %}{%
-    assign type = 'bool' %}{%
-  endif %}{%
-    for line in mapping.description %}
+  for line in mapping.description %}
   // {{ line }}{%
-    endfor %}
+  endfor %}{%
+  assign mode = mapping.requiredMode | downcase | underscore_non_wc %}{%
+  assign num_values = mapping.type | size %}{%
+  if num_values == 1 %}{%
+    assign type = mapping.type[0] %}{%
+    assign reader = 'value' %}{%
+    if type == 'float' %}{%
+      assign reader = 'float_value' %}{%
+    elsif type == 'boolean' %}{%
+      assign type = 'bool' %}{%
+    endif %}
   {{ type }} {{ name }}(bool do_set_mode = true) {
     if (do_set_mode) set_mode(mode_{{ mode }});
-    return {{ reader }}({{ value_index }});
+    return {{ reader }}({{ mapping.sourceValue[0] }});
   }
-{% endfor %}
+{% else %}
+  std::tuple<{%
+    for cur_type in mapping.type %}{%
+      assign type = cur_type %}{%
+      if type == 'boolean' %}{%
+        assign type = 'bool' %}{%
+      endif %}{{ type }}{%
+      unless forloop.last %}, {% endunless %}{%
+    endfor %}> {{ name }}(bool do_set_mode = true) {
+    if (do_set_mode) set_mode(mode_{{ mode }});
+    return std::make_tuple( {%
+    for value_index in mapping.sourceValue %}{%
+      assign reader = 'value' %}{%
+      if mapping.type[forloop.index] == 'float' %}{%
+        assign reader = 'float_value' %}{%
+      endif %}{{ reader }}({{ value_index }}){%
+      unless forloop.last %}, {% endunless %}{%
+    endfor %} );
+  }
+{% endif %}{%
+endfor %}
 };


### PR DESCRIPTION
Change template for special sensor types to account for the fact that
types and value indices are now lists in the specification.

Refs #10, depends on ev3dev/ev3dev-lang#169