### PR TITLE
fix device_index implementation

### DIFF
--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -263,6 +263,8 @@ int device::device_index() const
     _device_index = 0;
     for (auto it=_path.rbegin(); it!=_path.rend(); ++it)
     {
+      if(*it =='/')
+        continue;		
       if ((*it < '0') || (*it > '9'))
         break;
 


### PR DESCRIPTION
I am aware that this file is probably generated by autogen. 
This pull is mostly to expalin the bug and fix.

there is:
_path = dir + dp->d_name + '/';

in device_index we have to take into account the '/' character when
calculating index