### PR TITLE
Update cmake scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+dist: trusty
+language: cpp
+compiler:
+- gcc
+
 addons:
   apt:
     sources:
@@ -5,10 +10,6 @@ addons:
     packages:
     - gcc-5
     - g++-5
-
-language: cpp
-compiler:
-- gcc
 
 script:
 - mkdir -p build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,20 +6,74 @@ endif()
 
 project(ev3dev-lang-cpp)
 
+# Is this used directly or via add_subdirectory()
+set(EV3DEV_LANG_CPP_MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(EV3DEV_LANG_CPP_MASTER_PROJECT ON)
+endif()
+
 set(EV3DEV_PLATFORM "EV3" CACHE STRING "Target ev3dev platform (EV3/BRICKPI/PISTORMS)")
 set_property(CACHE EV3DEV_PLATFORM PROPERTY STRINGS "EV3" "BRICKPI" "PISTORMS")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-
 add_library(ev3dev STATIC ev3dev.cpp)
+add_library(ev3dev::ev3dev ALIAS ev3dev) # to match exported target
+
+target_include_directories(ev3dev PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+    )
+
+target_compile_options(ev3dev PUBLIC -std=c++0x)
+target_compile_definitions(ev3dev PUBLIC
+    _GLIBCXX_USE_NANOSLEEP
+    EV3DEV_PLATFORM_${EV3DEV_PLATFORM}
+    )
+target_link_libraries(ev3dev PUBLIC pthread)
 
 function(add_ev3_executable target sources)
     add_executable(${target} ${sources})
-    target_link_libraries(${target} ev3dev pthread)
+    target_link_libraries(${target} ev3dev)
 endfunction()
 
-enable_testing()
+if (EV3DEV_LANG_CPP_MASTER_PROJECT)
+    enable_testing()
+    add_subdirectory(tests)
 
-add_subdirectory(demos)
-add_subdirectory(tests)
+    add_subdirectory(demos)
+
+    #----------------------------------------------------------------------
+    # Install the library, header, and cmake configuration
+    #----------------------------------------------------------------------
+    install(FILES ev3dev.h DESTINATION include)
+    install(TARGETS ev3dev EXPORT ev3devTargets
+        LIBRARY DESTINATION  lib
+        ARCHIVE DESTINATION  lib
+        INCLUDES DESTINATION include
+        )
+
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ev3dev-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake/ev3dev-config.cmake"
+        COPYONLY
+        )
+
+    export(EXPORT ev3devTargets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/ev3dev-targets.cmake"
+        NAMESPACE ev3dev::
+        )
+
+    export(PACKAGE ev3dev)
+
+    install(EXPORT ev3devTargets
+        FILE ev3dev-targets.cmake
+        NAMESPACE ev3dev::
+        DESTINATION share/ev3dev/cmake
+        )
+
+    install(
+        FILES cmake/ev3dev-config.cmake
+        DESTINATION share/ev3dev/cmake
+        )
+endif()
+
+

--- a/README.md
+++ b/README.md
@@ -74,15 +74,7 @@ set(CMAKE_CXX_COMPILER "arm-linux-gnueabi-g++")
 
 Alternatively, you can set these environment variables during compilation (explained later).
 
-6. You also need the following define, without which the nanosleep-using demos won't compile:
-
-```cmake
-add_definitions(-D_GLIBCXX_USE_NANOSLEEP)
-```
-
-This line can be added immediately after the previous `set(...)` instructions.
-
-7. Now compile your programs and the generated binaries will be ready for EV3. This assumes that you have build tools such as `make` and `cmake` installed - if not, install them with `sudo apt-get install build-essential` (for make) and `sudo apt-get install cmake` for cmake. You can then perform compilation by invoking the following commands:
+6. Now compile your programs and the generated binaries will be ready for EV3. This assumes that you have build tools such as `make` and `cmake` installed - if not, install them with `sudo apt-get install build-essential` (for make) and `sudo apt-get install cmake` for cmake. You can then perform compilation by invoking the following commands:
 
 ```sh
 mkdir build && cd build
@@ -98,13 +90,13 @@ CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ cmake ..
 make
 ```
 
-8. The `build` directory will now contain folders with binary files ready to be executed on the EV3 brick. The easiest way to copy files is to use a program that supports SFTP, such as Filezilla. Remember that, by default, the username of the host system is `robot` and password is `maker`. The location of the path where the files are kept on disk is likely the following:
+7. The `build` directory will now contain folders with binary files ready to be executed on the EV3 brick. The easiest way to copy files is to use a program that supports SFTP, such as Filezilla. Remember that, by default, the username of the host system is `robot` and password is `maker`. The location of the path where the files are kept on disk is likely the following:
 
 ```
 c:\users\<YOUR USERNAME>\appdata\local\lxss\home\<YOUR USERNAME>\ev3dev-lang-cpp\build\
 ```
 
-9. Be sure to `chmod u+x myprogram` for every copied program before running the program, otherwise you'll get an `Access Denied` in SSH or some really weird error if executing from the brick.
+8. Be sure to `chmod u+x myprogram` for every copied program before running the program, otherwise you'll get an `Access Denied` in SSH or some really weird error if executing from the brick.
 
 ### Mac
 

--- a/cmake/ev3dev-config.cmake
+++ b/cmake/ev3dev-config.cmake
@@ -1,0 +1,17 @@
+# ev3dev-config.cmake - CMake configuration file for external
+# projects.
+#
+# Use this by invoking
+#
+#   find_package(ev3dev)
+#
+# followed by
+#
+#   add_executable(myrobot myrobot.cpp)
+#   target_link_libraries(myrobot ev3dev::ev3dev)
+#
+# The module defines ev3dev::ev3dev IMPORTED target that takes care of proper
+# compile and link options.
+
+include("${CMAKE_CURRENT_LIST_DIR}/ev3dev-targets.cmake")
+message(STATUS "Found ev3dev")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,17 @@
-add_executable(api_tests api_tests.cpp)
+add_executable(api_tests
+    api_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ev3dev.cpp
+    )
+
+target_include_directories(api_tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    )
+
+target_compile_options(api_tests PRIVATE -std=c++0x)
 
 target_compile_definitions(api_tests PRIVATE
     SYS_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys/arena"
     FAKE_SYS="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys"
     )
-target_link_libraries(api_tests ev3dev)
 
 add_test(api_tests api_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_definitions(-DSYS_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys/arena")
-add_definitions(-DFAKE_SYS="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys")
-add_executable(api_tests api_tests.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../ev3dev.cpp)
+add_executable(api_tests api_tests.cpp)
+
+target_compile_definitions(api_tests PRIVATE
+    SYS_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys/arena"
+    FAKE_SYS="${CMAKE_CURRENT_SOURCE_DIR}/fake-sys"
+    )
+target_link_libraries(api_tests ev3dev)
+
 add_test(api_tests api_tests)


### PR DESCRIPTION
Provide install target, which installs the library, the header, and the cmake configuration scripts to `${CMAKE_INSTALL_PREFIX}` dir. (I guess this can be used later to prepare a debian package).

After that, users may link to the library by adding the following to their cmake scripts:
```cmake
find_package(ev3dev)
add_executable(myrobot myrobot.cpp)
target_link_libraries(myrobot ev3dev::ev3dev)
```
The [IMPORTED](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) target `ev3dev::ev3dev`, when linked against, will propagate the appropriate compile options, preprocessor definitions, and linker flags to the user target.

Also register the build directory in the cmake [user package registry](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#user-package-registry), so
that `find_package(ev3dev)` may be used as soon as local copy of `ev3dev-lang-cpp` has been configured, without a system-wide installation.