### PR TITLE
add constructor to ultrasonic for using NXT and EV3 together

### DIFF
--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -666,6 +666,11 @@ ultrasonic_sensor::ultrasonic_sensor(address_type address) :
 {
 }
 
+ultrasonic_sensor::ultrasonic_sensor(address_type address, const std::set<sensor_type>& sensorTypes) :
+  sensor(address, sensorTypes)
+{
+}
+
 //-----------------------------------------------------------------------------
 
 //~autogen generic-define-property-value specialSensorTypes.gyroSensor>currentClass

--- a/ev3dev.h
+++ b/ev3dev.h
@@ -447,6 +447,8 @@ class ultrasonic_sensor : public sensor
 public:
   ultrasonic_sensor(address_type address = INPUT_AUTO);
 
+  ultrasonic_sensor(address_type address, const std::set<sensor_type>& sensorTypes);
+
   // Continuous measurement in centimeters.
   static constexpr char mode_us_dist_cm[] = "US-DIST-CM";
 


### PR DESCRIPTION
May be you find it useful, because I used it for my EV3 to connect two ultrasonic sensors from an NXT and an EV3. Here is an example, how the new constructor can be used:
	ultrasonic_sensor ultraSonicL(INPUT_AUTO, {sensor::ev3_infrared});
	ultrasonic_sensor ultraSonicR(INPUT_AUTO, {sensor::nxt_ultrasonic});
