### PR TITLE
cmake: Don't forcibly export C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(ev3dev PUBLIC
     $<INSTALL_INTERFACE:include>
     )
 
-target_compile_options(ev3dev PUBLIC -std=c++0x)
 target_compile_definitions(ev3dev PUBLIC
     _GLIBCXX_USE_NANOSLEEP
     EV3DEV_PLATFORM_${EV3DEV_PLATFORM}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type")
 endif()
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project(ev3dev-lang-cpp)
 
 # Is this used directly or via add_subdirectory()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type selected, default to RelWithDebInfo")
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type")


### PR DESCRIPTION
This PR fixes issue #51, if the user has cmake v3.1 or newer, which is almost certainly most users.

For older versions of cmake there doesn't seem to be a nice way to check if the user has already specified a C++ version, so I have preserved the old behaviour where the C++ version is also set for any parent projects.