### PR TITLE
Add support for NXT motors

### DIFF
--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -751,6 +751,7 @@ light_sensor::light_sensor(address_type address) :
 
 constexpr char motor::motor_large[];
 constexpr char motor::motor_medium[];
+constexpr char motor::motor_nxt[];
 
 //~autogen generic-define-property-value classes.motor>currentClass
 
@@ -817,6 +818,11 @@ medium_motor::medium_motor(address_type address) : motor(address, motor_medium)
 //-----------------------------------------------------------------------------
 
 large_motor::large_motor(address_type address) : motor(address, motor_large)
+{
+}
+
+//-----------------------------------------------------------------------------
+nxt_motor::nxt_motor(address_type address) : motor(address, motor_nxt)
 {
 }
 

--- a/ev3dev.h
+++ b/ev3dev.h
@@ -679,6 +679,7 @@ public:
 
   static constexpr char motor_large[]  = "lego-ev3-l-motor";
   static constexpr char motor_medium[] = "lego-ev3-m-motor";
+  static constexpr char motor_nxt[] = "lego-nxt-motor";
 
   using device::connected;
   using device::device_index;
@@ -1063,6 +1064,15 @@ class large_motor : public motor
 {
 public:
   large_motor(address_type address = OUTPUT_AUTO);
+};
+
+//-----------------------------------------------------------------------------
+
+// NXT motor
+class nxt_motor : public motor
+{
+public:
+  nxt_motor(address_type address = OUTPUT_AUTO);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This small patch adds support for NXT motors.

For users of the BrickPi, motors always appear as NXT motors so this is also useful for large Lego motors plugged into a BrickPi (which is my use case).