### PR TITLE
Fix gyro_sensor on BrickPi

### DIFF
--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -495,6 +495,10 @@ sensor::sensor(address_type address, const std::set<sensor_type> &types)
 
 //-----------------------------------------------------------------------------
 
+/*
+ * Constructs a sensor, setting the device explicitly. We need to do this on
+ * BrickPis as they cannot autodetect the sensor type.
+ */
 sensor::sensor(address_type address,
                const std::set<sensor_type> &types,
                const std::string &mode,

--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -264,7 +264,7 @@ int device::device_index() const
     for (auto it=_path.rbegin(); it!=_path.rend(); ++it)
     {
       if(*it =='/')
-        continue;		
+        continue;
       if ((*it < '0') || (*it > '9'))
         break;
 
@@ -495,6 +495,23 @@ sensor::sensor(address_type address, const std::set<sensor_type> &types)
 
 //-----------------------------------------------------------------------------
 
+sensor::sensor(address_type address,
+               const std::set<sensor_type> &types,
+               const std::string &mode,
+               const std::string &device)
+{
+  {
+    lego_port port(address);
+    port.set_mode(mode);
+    port.set_set_device(device);
+  }
+
+  connect({{"address", {address}},
+           {"driver_name", types}});
+}
+
+//-----------------------------------------------------------------------------
+
 bool sensor::connect(const std::map<std::string, std::set<std::string>> &match) noexcept
 {
   static const std::string _strClassDir { SYS_ROOT "/lego-sensor/" };
@@ -684,7 +701,7 @@ constexpr char gyro_sensor::mode_gyro_cal[];
 //~autogen
 
 gyro_sensor::gyro_sensor(address_type address) :
-  sensor(address, { ev3_gyro })
+  sensor(address, { ev3_gyro }, "ev3-uart", ev3_gyro)
 {
 }
 

--- a/ev3dev.cpp
+++ b/ev3dev.cpp
@@ -701,7 +701,11 @@ constexpr char gyro_sensor::mode_gyro_cal[];
 //~autogen
 
 gyro_sensor::gyro_sensor(address_type address) :
+#if defined(EV3DEV_PLATFORM_BRICKPI) || defined(EV3DEV_PLATFORM_BRICKPI3)
   sensor(address, { ev3_gyro }, "ev3-uart", ev3_gyro)
+#else
+  sensor(address, { ev3_gyro })
+#endif
 {
 }
 

--- a/ev3dev.h
+++ b/ev3dev.h
@@ -173,6 +173,10 @@ public:
 
   sensor(address_type);
   sensor(address_type, const std::set<sensor_type>&);
+  sensor(address_type,
+         const std::set<sensor_type> &,
+         const std::string &mode,
+         const std::string &device);
 
   using device::connected;
   using device::device_index;


### PR DESCRIPTION
On the BrickPi, we have to explicitly set the sensor type as it cannot
be automatically detected, as it is with ev3dev running on the
Mindstorms computer.

This PR adds an extra constructor to the sensor class, which allows
for explicitly setting the sensor type, and makes use of it in the
gyro_sensor class.