### PR TITLE
Added compiler for .c files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ vi CMakeLists.txt
 Just after the `project(...)` declaration, set the C/C++ compilers by adding the following lines:
 
 ```cmake
+set(CMAKE_C_COMPILER "arm-linux-gnueabi-gcc")
 set(CMAKE_CC_COMPILER "arm-linux-gnueabi-gcc")
 set(CMAKE_CXX_COMPILER "arm-linux-gnueabi-g++")
 ```


### PR DESCRIPTION
It seems like you are able to compile `.cc` files using `CMAKE_CC_COMPILER`, but if you would try to compile any `.c` library the default systems compiler is used again. So to circumvent this you need to also define `CMAKE_C_COMPILER` to set the compiler for `.c` files.